### PR TITLE
Add voting mode, download Lemmy release binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ plugins/typescript_push_webhook/node_modules
 # lemmy plugins
 *.wasm
 
+# lemmy binary
+lemmy_server

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,6 +1,6 @@
 steps:
   prettier_check:
-    image: tmknom/prettier:3.2.5
+    image: jauderho/prettier:3.9.5-alpine
     commands:
       - prettier -c .
     when:
@@ -27,7 +27,7 @@ steps:
       - event: [pull_request, tag]
 
   build_rust_plugins:
-    image: rust:1.91
+    image: rust:1.96
     commands:
       - ./scripts/ci-build-rust.sh rust_allowed_voters debug wasm32-wasip1
       - ./scripts/ci-build-rust.sh rust_lingua
@@ -36,7 +36,7 @@ steps:
       - event: [pull_request]
 
   build_rust_plugins_release:
-    image: rust:1.91
+    image: rust:1.96
     commands:
       - ./scripts/ci-build-rust.sh rust_allowed_voters release wasm32-wasip1
       - ./scripts/ci-build-rust.sh rust_lingua release
@@ -63,7 +63,9 @@ steps:
       DANGER_PLUGIN_SKIP_HASH_CHECK: 1
     commands:
       - npm install -g corepack@latest && corepack enable pnpm
-      - apt-get update && apt-get install -y --no-install-recommends --no-install-suggests bash curl postgresql-client ca-certificates
+      - apt-get update && apt-get install -y
+        --no-install-recommends --no-install-suggests
+        bash curl postgresql-client ca-certificates wget
       - bash tests/prepare.sh
       - cd tests/
       - pnpm i

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ npm run build
 
 ## Rust: Allowed Voters
 
-Listens to `new_vote` hook, then calls `/api/v4/person` to get details about the voter. It only allows downvotes if the user has made at least 5 posts before. See [rust-pdk readme](https://github.com/extism/rust-pdk?tab=readme-ov-file) for setup and detailed documentation.
+Listens to `new_vote` hook, then calls `/api/v4/person` to get details about the voter. Set `min_posts_for_downvote` to allow only users with at least X
+posts to downvote. Or set `allowed_downvote_instances` to a comma-separated
+list of domains to allow downvotes only from those domains.
+
+See [rust-pdk readme](https://github.com/extism/rust-pdk?tab=readme-ov-file) for setup and detailed documentation.
 
 Use the following steps to compile it:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Lemmy Plugins
 
 This repository contains various example plugins for Lemmy. See the following links for more information:
+
 - [Lemmy Plugin Documentation](https://join-lemmy.org/docs/contributors/08-plugins.html)
 - [Lemmy Plugin RFC](https://github.com/LemmyNet/rfcs/blob/main/0008-plugins.md)
 - [Extism documentation](https://extism.org/docs/quickstart/plugin-quickstart)

--- a/config/config.hjson
+++ b/config/config.hjson
@@ -10,6 +10,9 @@
     {
       file: "plugins/rust_allowed_voters.wasm"
       allowed_hosts: ["0.0.0.0"]
+      config: {
+        downvote_mode: none
+      }
     },
     {
       file: plugins/typescript_push_webhook.wasm

--- a/config/config.hjson
+++ b/config/config.hjson
@@ -11,7 +11,7 @@
       file: "plugins/rust_allowed_voters.wasm"
       allowed_hosts: ["0.0.0.0"]
       config: {
-        downvote_mode: none
+        allowed_downvote_instances: lemmy-alpha
       }
     },
     {

--- a/config/lemmy_alpha.hjson
+++ b/config/lemmy_alpha.hjson
@@ -17,10 +17,13 @@
     {
       file: "plugins/rust_allowed_voters.wasm"
       allowed_hosts: ["0.0.0.0"]
+      "config": {
+        "min_posts_for_downvote": "5"
+      }
     },
     {
       file: plugins/typescript_push_webhook.wasm
-      "allowed_hosts": ["127.0.0.1"],
+      "allowed_hosts": ["127.0.0.1"]
       "config": {
         "notify_url": "http://127.0.0.1:8927"
       }

--- a/plugins/rust_allowed_voters/Cargo.lock
+++ b/plugins/rust_allowed_voters/Cargo.lock
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +98,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -147,9 +156,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -157,11 +166,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -171,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -182,11 +190,10 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -279,9 +286,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "extism-convert"
-version = "1.13.0"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6612b4e92559eeb4c2dac88a53ee8b4729bea64025befcdeb2b3677e62fc1d"
+checksum = "ad19858c4c462309a8f3a20abec53e8603bda1eefda26c8bfab51d5516b40cbb"
 dependencies = [
  "anyhow",
  "base64",
@@ -295,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "extism-convert-macros"
-version = "1.13.0"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525831f1f15079a7c43514905579aac10f90fee46bc6353b683ed632029dd945"
+checksum = "5f2932799f6d9f9646f97b65287f6bb2addc75a0ee61e40fb24559a7540dd928"
 dependencies = [
  "manyhow",
  "proc-macro-crate",
@@ -348,12 +355,6 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -620,8 +621,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6162a441f4a6094eca658c01feac74c65f1c0fbfa2ec74b9edb672ebe8ef36"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -644,7 +646,6 @@ dependencies = [
  "lemmy_db_views_private_message",
  "lemmy_db_views_registration_applications",
  "lemmy_db_views_report_combined",
- "lemmy_db_views_search_combined",
  "lemmy_db_views_site",
  "lemmy_db_views_vote",
  "lemmy_diesel_utils",
@@ -653,8 +654,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6447cb04b6701b1fdffe0bc53619868265c1e0031442be6f4e2db3b62aea7058"
 dependencies = [
  "chrono",
  "derive-new",
@@ -668,8 +670,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema_file"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc3dac3719fd99c5db9b7e0a59e71e005ababd62e788b495a0510812c39630d"
 dependencies = [
  "serde",
  "strum",
@@ -677,8 +680,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_comment"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ccf77b11d8d22d6da9c833003ac9fad78f0a52c135041c4e5386d3c42482216"
 dependencies = [
  "chrono",
  "lemmy_db_schema",
@@ -690,8 +694,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_community"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fcd881785cf21a85baaeaf592a4d46a8f24cca17e386378ecc8904718568861"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -703,8 +708,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_community_follower"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb0cbb2dd58a41c5e54a6e8770fc0a0bd17c2a0f0d20f738833a4b7e21cccb9"
 dependencies = [
  "chrono",
  "lemmy_db_schema",
@@ -715,8 +721,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_community_follower_approval"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c537833acc527d0b54dffb6a60fb3ea5bfa8308fc7d3af2a2713a543044d42"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -727,8 +734,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_community_moderator"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04a802adf7b1ea32c31f7e84a52dee53dc0cbfb5d08782e2ad20af6b31d19bf"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -738,8 +746,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_custom_emoji"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9c1a77be8a669ad173835ee1c0a7d85c3cc789ecf5d13a803e2be0d914dc37"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -750,8 +759,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_local_image"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7992b516d0ff4b6313087233ce98788bb06533e4dca42610b286b50942be09d"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -763,8 +773,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_local_user"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "393db7b6e4d26f43a63adc5218a77d013980ad2220d8989baeea2386624c4c8b"
 dependencies = [
  "chrono",
  "lemmy_db_schema",
@@ -776,8 +787,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_modlog"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9bf000a12f55820bc11b1a880d0ea1cbdf494b1559438cb0e14fcffabbaa3e"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -788,8 +800,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_notification"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c412e07ff0a5fabd24de1bdb290d9f672b97e72d3a998b46ea740656870f0ef3"
 dependencies = [
  "chrono",
  "lemmy_db_schema",
@@ -805,8 +818,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_person"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376b006ce300e7ffe80a4e92fa87aaecbe7889751b810da57f6d8a1a20f3da4"
 dependencies = [
  "chrono",
  "lemmy_db_schema",
@@ -820,10 +834,10 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_person_content_combined"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b79ae22849cdb775be1b55a865f723f6daf74e6becb92dbf02a566a3a753ee"
 dependencies = [
- "derive-new",
  "lemmy_db_schema",
  "lemmy_db_schema_file",
  "lemmy_db_views_local_user",
@@ -835,8 +849,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_person_liked_combined"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171f7853b9c2ef7d36b61b7a769445899d3326709bd89e7ab0c2a98e04edb49c"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -849,8 +864,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_person_saved_combined"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ffbe7b67f392d2e1aaef2c3280fe860a13bbc22aafd705309206e4839a33fa"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -863,22 +879,26 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_post"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ff101989a30e5b2b9f2421e6236e08b86522c498ed93fa9ab2eadcb1eeda52"
 dependencies = [
  "chrono",
  "lemmy_db_schema",
  "lemmy_db_schema_file",
+ "lemmy_db_views_community",
  "lemmy_diesel_utils",
  "serde",
  "serde_with",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "lemmy_db_views_post_comment_combined"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e401f5504c276e15e879e66d1ea57e2d39caf8396e9d446c8c69416146c9855"
 dependencies = [
  "chrono",
  "lemmy_db_schema",
@@ -889,8 +909,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_private_message"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58d2596552b152d1be6ba349afbc5c8d875cc633a390639d9905a763da34ded"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -900,8 +921,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_registration_applications"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801969a0be7a1002df7dd2d2622421e143651c104ae66ac554c580fc8971a97d"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -912,8 +934,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_report_combined"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d204a0c00c9490bcc65699d601c4889af540d05f33a7cfb3f09b194cdbba46"
 dependencies = [
  "chrono",
  "lemmy_db_schema",
@@ -925,15 +948,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "lemmy_db_views_search_combined"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+name = "lemmy_db_views_site"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9674d498b76aa1476a48978ddec0c19302c78a889f737db821b3ccb4341d5bb8"
 dependencies = [
- "chrono",
+ "extism-convert",
  "lemmy_db_schema",
  "lemmy_db_schema_file",
  "lemmy_db_views_comment",
  "lemmy_db_views_community",
+ "lemmy_db_views_community_follower",
+ "lemmy_db_views_community_moderator",
  "lemmy_db_views_local_user",
  "lemmy_db_views_person",
  "lemmy_db_views_post",
@@ -944,29 +970,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lemmy_db_views_site"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
-dependencies = [
- "chrono",
- "extism-convert",
- "lemmy_db_schema",
- "lemmy_db_schema_file",
- "lemmy_db_views_community",
- "lemmy_db_views_community_follower",
- "lemmy_db_views_community_moderator",
- "lemmy_db_views_local_user",
- "lemmy_db_views_person",
- "lemmy_diesel_utils",
- "serde",
- "serde_with",
- "url",
-]
-
-[[package]]
 name = "lemmy_db_views_vote"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2cda7a00f2541bb1c04c1d5edac824052f938a3eccf06703b0cbc914b91f61f"
 dependencies = [
  "lemmy_db_schema",
  "lemmy_db_schema_file",
@@ -977,8 +984,9 @@ dependencies = [
 
 [[package]]
 name = "lemmy_diesel_utils"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a6442acf078abfc9768d1f17c4d566ad60bb67826a03d7d2b3e0445a5c30d3"
 dependencies = [
  "diesel-derive-newtype",
  "serde",
@@ -988,10 +996,10 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "1.0.0-alpha.12"
-source = "git+https://github.com/LemmyNet/lemmy.git?branch=captcha-plugin#ad57ff1f39559bcdfc3b297a15701fbf47c1ad81"
+version = "1.0.0-test-fix-publish-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cad978b34c758ea2ea3fe74d140dab1e10eea689ce9be69eefa558797415d7"
 dependencies = [
- "cfg-if",
  "chrono",
  "clearurls",
  "git-version",
@@ -1002,6 +1010,7 @@ dependencies = [
  "markdown-it-sub",
  "markdown-it-sup",
  "serde",
+ "serde_with",
  "strum",
  "unicode-segmentation",
 ]
@@ -1079,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "markdown-it-block-spoiler"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecff0b200e54209a2f2b5e583aa02b978ed6f50f538b3c4001f4a576b82285e3"
+checksum = "558832b13260a7529dd67285a81f7a06b12339a104e1be3aded854e303b7e931"
 dependencies = [
  "itertools",
  "markdown-it",
@@ -1143,9 +1152,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1447,11 +1456,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1466,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1515,18 +1525,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1569,12 +1579,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1584,15 +1593,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/plugins/rust_allowed_voters/Cargo.toml
+++ b/plugins/rust_allowed_voters/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 extism-pdk = "1.3.0"
 serde = { version = "1", features = ["derive"] }
-lemmy_api_common = { git = "https://github.com/LemmyNet/lemmy.git", branch = "captcha-plugin" }
+lemmy_api_common = "1.0.0-beta.1"

--- a/plugins/rust_allowed_voters/src/lib.rs
+++ b/plugins/rust_allowed_voters/src/lib.rs
@@ -2,8 +2,6 @@ use extism_pdk::*;
 use lemmy_api_common::person::GetPersonDetailsResponse;
 use lemmy_api_common::plugin::PluginMetadata;
 use lemmy_api_common::post::PostLikeForm;
-use serde::Deserialize;
-use serde::de::IntoDeserializer;
 
 // Returns info about the plugin which gets included in /api/v4/site
 //go:wasmexport metadata
@@ -16,28 +14,14 @@ pub fn metadata() -> FnResult<Json<PluginMetadata>> {
     )))
 }
 
-#[derive(PartialEq, Default, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum VotingMode {
-    #[default]
-    All,
-    Local,
-    None,
-}
-
-fn parse_voting_mode(s: Option<String>) -> Result<VotingMode, serde::de::value::Error> {
-    let s = s.unwrap_or("all".to_string());
-    VotingMode::deserialize(s.into_deserializer())
-}
 #[plugin_fn]
 pub fn post_before_vote(Json(vote): Json<PostLikeForm>) -> FnResult<Json<PostLikeForm>> {
     let lemmy_url = config::get("lemmy_url")?.unwrap();
     let person_id = vote.person_id.0;
-    let is_upvote = vote.vote_is_upvote == Some(Some(true));
     let is_downvote = vote.vote_is_upvote == Some(Some(false));
 
-    let upvote_mode: VotingMode = parse_voting_mode(config::get("upvote_mode")?)?;
-    let downvote_mode: VotingMode = parse_voting_mode(config::get("downvote_mode")?)?;
+    let allowed_downvote_instances = config::get("allowed_downvote_instances")?.unwrap_or_default();
+    let allowed_downvote_instances = allowed_downvote_instances.split(",").collect::<Vec<_>>();
 
     let req = HttpRequest {
         url: format!("{lemmy_url}api/v4/person?person_id={person_id}"),
@@ -45,16 +29,12 @@ pub fn post_before_vote(Json(vote): Json<PostLikeForm>) -> FnResult<Json<PostLik
         method: Some("GET".to_string()),
     };
     let res: GetPersonDetailsResponse = http::request::<()>(&req, None)?.json()?;
-    let is_local = res.person_view.person.local;
-    if is_upvote
-        && (upvote_mode == VotingMode::None || (upvote_mode == VotingMode::Local && !is_local))
-    {
-        return Err(Error::msg("upvote not allowed").into());
-    }
-    if is_downvote
-        && (downvote_mode == VotingMode::None || (downvote_mode == VotingMode::Local && !is_local))
-    {
-        return Err(Error::msg("downvote not allowed").into());
+    let person_is_local = res.person_view.person.local;
+    if is_downvote && !person_is_local && !allowed_downvote_instances.is_empty() {
+        let person_instance = res.person_view.person.ap_id.domain().unwrap();
+        if !allowed_downvote_instances.contains(&person_instance) {
+            return Err(Error::msg(format!("downvote not allowed from {person_instance}")).into());
+        }
     }
 
     let min_posts_for_downvote: i32 = config::get("min_posts_for_downvote")?

--- a/plugins/rust_allowed_voters/src/lib.rs
+++ b/plugins/rust_allowed_voters/src/lib.rs
@@ -2,6 +2,8 @@ use extism_pdk::*;
 use lemmy_api_common::person::GetPersonDetailsResponse;
 use lemmy_api_common::plugin::PluginMetadata;
 use lemmy_api_common::post::PostLikeForm;
+use serde::Deserialize;
+use serde::de::IntoDeserializer;
 
 // Returns info about the plugin which gets included in /api/v4/site
 //go:wasmexport metadata
@@ -14,19 +16,53 @@ pub fn metadata() -> FnResult<Json<PluginMetadata>> {
     )))
 }
 
+#[derive(PartialEq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum VotingMode {
+    #[default]
+    All,
+    Local,
+    None,
+}
+
+fn parse_voting_mode(s: Option<String>) -> Result<VotingMode, serde::de::value::Error> {
+    let s = s.unwrap_or("all".to_string());
+    VotingMode::deserialize(s.into_deserializer())
+}
 #[plugin_fn]
 pub fn post_before_vote(Json(vote): Json<PostLikeForm>) -> FnResult<Json<PostLikeForm>> {
     let lemmy_url = config::get("lemmy_url")?.unwrap();
     let person_id = vote.person_id.0;
+    let is_upvote = vote.vote_is_upvote == Some(Some(true));
+    let is_downvote = vote.vote_is_upvote == Some(Some(false));
+
+    let upvote_mode: VotingMode = parse_voting_mode(config::get("upvote_mode")?)?;
+    let downvote_mode: VotingMode = parse_voting_mode(config::get("downvote_mode")?)?;
+
     let req = HttpRequest {
         url: format!("{lemmy_url}api/v4/person?person_id={person_id}"),
         headers: Default::default(),
         method: Some("GET".to_string()),
     };
     let res: GetPersonDetailsResponse = http::request::<()>(&req, None)?.json()?;
+    let is_local = res.person_view.person.local;
+    if is_upvote
+        && (upvote_mode == VotingMode::None || (upvote_mode == VotingMode::Local && !is_local))
+    {
+        return Err(Error::msg("upvote not allowed").into());
+    }
+    if is_downvote
+        && (downvote_mode == VotingMode::None || (downvote_mode == VotingMode::Local && !is_local))
+    {
+        return Err(Error::msg("downvote not allowed").into());
+    }
+
+    let min_posts_for_downvote: i32 = config::get("min_posts_for_downvote")?
+        .as_deref()
+        .map(str::parse)
+        .unwrap_or(Ok(-1))?;
     let person_post_count = res.person_view.person.post_count;
-    let is_upvote = vote.vote_is_upvote.unwrap_or_default().unwrap_or_default();
-    if person_post_count < 5 && !is_upvote {
+    if min_posts_for_downvote != -1 && person_post_count < min_posts_for_downvote && is_downvote {
         return Err(Error::msg("user is not allowed to downvote").into());
     }
     Ok(Json(vote))

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+if [ ! -f lemmy_server ]; then
+  wget "https://github.com/LemmyNet/lemmy/releases/download/1.0.0-beta.1/lemmy_server.gz"
+  gunzip lemmy_server.gz -f
+  chmod +x lemmy_server
+fi
+
+DANGER_PLUGIN_SKIP_HASH_CHECK=1 ./lemmy_server

--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -29,6 +29,13 @@ fi
 
 LOG_DIR=tests/log
 mkdir -p $LOG_DIR
+export DANGER_PLUGIN_SKIP_HASH_CHECK=1
+
+if [ ! -f lemmy_server ]; then
+  wget "https://github.com/LemmyNet/lemmy/releases/download/1.0.0-beta.1/lemmy_server.gz"
+  gunzip lemmy_server.gz -f
+  chmod +x lemmy_server
+fi
 
 echo "start alpha"
 LEMMY_CONFIG_LOCATION=./config/lemmy_alpha.hjson \


### PR DESCRIPTION
Adds instance-wide vote settings to `allowed_votes` plugin, identical to the ones removed in https://github.com/LemmyNet/lemmy/pull/6603. Only covers post votes for now, but comment votes can easily be handled in the same way with a little bit of copy-paste.